### PR TITLE
Make it compile on Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: main.c bmp.o
-	gcc -O2 bmp.o main.c -o raytracer
+	gcc -O2 bmp.o main.c -o raytracer -lm
 
 #Darf aus irgendeinem Grund nicht mit O2 kompiliert werden...
 bmp.o: bmp.c

--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ A very small and very incapable raytracer in C
 
 Contains a hard coded scene (Cornell box without spheres) and outputs to a file called "test.bmp".
 
-Just run make and then ./raytracer. Tested on OSX.
+Just run make and then ./raytracer. Tested on OSX, Linux and Cygwin.
+


### PR DESCRIPTION
This project would build on Cygwin but it doesn't build on Linux due to a missing '-lm' option passed as a command-line argument.
```
$ make
gcc -lm -O2 bmp.o main.c -o raytracer
/usr/bin/ld: /tmp/cc45hWdu.o: in function `traceRay':
main.c:(.text+0x525): undefined reference to `sqrt'
/usr/bin/ld: /tmp/cc45hWdu.o: in function `normalizeColor':
main.c:(.text+0x555): undefined reference to `fmax'
/usr/bin/ld: main.c:(.text+0x55f): undefined reference to `fmax'
/usr/bin/ld: /tmp/cc45hWdu.o: in function `vectorLength':
main.c:(.text+0x176): undefined reference to `sqrt'
collect2: error: ld returned 1 exit status
make: *** [Makefile:2: all] Error 1
```