### PR TITLE
Fix a few compiler warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: main.c bmp.o
-	gcc -O2 bmp.o main.c -o raytracer -lm
+	gcc -Wall -O2 bmp.o main.c -o raytracer -lm
 
 #Darf aus irgendeinem Grund nicht mit O2 kompiliert werden...
 bmp.o: bmp.c
-	gcc -c bmp.c -o bmp.o
+	gcc -Wall -c bmp.c -o bmp.o
 

--- a/main.c
+++ b/main.c
@@ -44,15 +44,15 @@ Ray getRay(int x, int y) {
 Plane* createBox() {
 	Plane* box = (Plane*)malloc(5*sizeof(Plane));
 	int size = 5;
-	Plane p0 = {-1, 0, 0, size, 255, 0, 100};//links
+	Plane p0 = { { -1, 0, 0 }, size, { 255, 0, 100 } };//links
 	box[0] = p0;
-	Plane p1 = {1, 0, 0, size, 0, 255, 0};//rechts
+	Plane p1 = { { 1, 0, 0 }, size, { 0, 255, 0 } };//rechts
 	box[1] = p1;
-	Plane p2 = {0, 0, -1, size, 255,255,255};//hinten
+	Plane p2 = { { 0, 0, -1 }, size, { 255,255,255 } };//hinten
 	box[2] = p2;
-	Plane p3 = {0, 1, 0, size, 255, 255, 255};//oben
+	Plane p3 = { { 0, 1, 0 }, size, { 255, 255, 255 } };//oben
 	box[3] = p3;
-	Plane p4 = {0, -1, 0, size, 255, 255, 255};//unten
+	Plane p4 = { { 0, -1, 0 }, size, { 255, 255, 255 } };//unten
 	box[4] = p4;
 	return box;
 }	
@@ -73,7 +73,7 @@ double scalarProduct(Vector* v1, Vector* v2) {
 Intersection rayHitsPlane(Ray* r, Plane* p)  {
 	double gamma = scalarProduct(&(r->direction), &(p->normal));
 	double side = p->distance - scalarProduct(&(p->normal), &(r->origin));
-	Intersection intersect  = {0, 0, 0, 0, p};
+	Intersection intersect  = { { 0, 0, 0 }, 0, p};
 	if( gamma * side > epsilon) {
 		double lambda = side / gamma;
 		intersect.point.x = r->origin.x + r->direction.x * lambda;


### PR DESCRIPTION
Pass '-Wall' as a command-line argument to GCC, and the following compiler warnings appear.
```
main.c: In function ‘createBox’:
main.c:47:20: warning: missing braces around initializer [-Wmissing-braces]
   47 |         Plane p0 = {-1, 0, 0, size, 255, 0, 100};//links
      |                    ^
      |                     {       }       {          }
main.c:49:20: warning: missing braces around initializer [-Wmissing-braces]
   49 |         Plane p1 = {1, 0, 0, size, 0, 255, 0};//rechts
      |                    ^
      |                     {      }       {        }
main.c:51:20: warning: missing braces around initializer [-Wmissing-braces]
   51 |         Plane p2 = {0, 0, -1, size, 255,255,255};//hinten
      |                    ^
      |                     {       }       {          }
main.c:53:20: warning: missing braces around initializer [-Wmissing-braces]
   53 |         Plane p3 = {0, 1, 0, size, 255, 255, 255};//oben
      |                    ^
      |                     {      }       {            }
main.c:55:20: warning: missing braces around initializer [-Wmissing-braces]
   55 |         Plane p4 = {0, -1, 0, size, 255, 255, 255};//unten
      |                    ^
      |                     {       }       {            }
main.c: In function ‘rayHitsPlane’:
main.c:76:35: warning: missing braces around initializer [-Wmissing-braces]
   76 |         Intersection intersect  = {0, 0, 0, 0, p};
      |                                   ^
      |                                    {      }
```