### PR TITLE
Make it compile on OpenBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: main.c bmp.o
-	gcc -Wall -O2 bmp.o main.c -o raytracer -lm
+	${CC} -Wall -O2 bmp.o main.c -o raytracer -lm
 
 #Darf aus irgendeinem Grund nicht mit O2 kompiliert werden...
 bmp.o: bmp.c
-	gcc -Wall -c bmp.c -o bmp.o
+	${CC} -Wall -c bmp.c -o bmp.o
 

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ A very small and very incapable raytracer in C
 
 Contains a hard coded scene (Cornell box without spheres) and outputs to a file called "test.bmp".
 
-Just run make and then ./raytracer. Tested on OSX, Linux and Cygwin.
+Just run make and then ./raytracer. Tested on OSX, OpenBSD, Linux and Cygwin.
 

--- a/bmp.c
+++ b/bmp.c
@@ -64,7 +64,8 @@ write_bmp(const char *filename, int width, int height, char *rgb)
 
     bytesPerLine = (3 * (width + 1) / 4) * 4;
 
-    strcpy(bmph.bfType, "BM");
+    bmph.bfType[0] = 'B';
+    bmph.bfType[1] = 'M';
     bmph.bfOffBits = 54;
     bmph.bfSize = bmph.bfOffBits + bytesPerLine * height;
     bmph.bfReserved = 0;


### PR DESCRIPTION
### Makefile

Replace 'gcc' with a compiler variable so it can compile with LLVM, if installed.

### bmp.c

Don't call 'strcpy()' but set two characters of an array.

### README.md

Add OpenBSD to the list of operating systems. I've tested it on OpenBSD 7.5.